### PR TITLE
fixed keyboard shortcuts on MacOS [#7892]

### DIFF
--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -2,12 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
- :root[platform="mac"] .welcomebox .shortcutKey,
- .launchpad-root[platform="mac"] .welcomebox .shortcutKey {
-   --monospace-font-family: monospace;
-   font-weight: 600;
- }
-
 .welcomebox {
   position: absolute;
   top: var(--editor-header-height);
@@ -67,6 +61,12 @@
   font-size: 14px;
   line-height: 18px;
   color: var(--theme-body-color);
+}
+
+:root[platform="mac"] .welcomebox .shortcutKey,
+.launchpad-root[platform="mac"] .welcomebox .shortcutKey {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-weight: 500;
 }
 
 .shortcutLabel {

--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -2,6 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+ :root[platform="mac"] .welcomebox .shortcutKey,
+ .launchpad-root[platform="mac"] .welcomebox .shortcutKey {
+   --monospace-font-family: monospace;
+   font-weight: 600;
+ }
+
 .welcomebox {
   position: absolute;
   top: var(--editor-header-height);

--- a/src/utils/text.js
+++ b/src/utils/text.js
@@ -29,10 +29,10 @@ const isMacOS = appinfo.OS === "Darwin";
 export function formatKeyShortcut(shortcut: string): string {
   if (isMacOS) {
     return shortcut
-      .replace(/Shift\+/g, "\u21E7 ")
-      .replace(/Command\+|Cmd\+/g, "\u2318 ")
-      .replace(/CommandOrControl\+|CmdOrCtrl\+/g, "\u2318 ")
-      .replace(/Alt\+/g, "\u2325 ");
+      .replace(/Shift\+/g, "\u21E7")
+      .replace(/Command\+|Cmd\+/g, "\u2318")
+      .replace(/CommandOrControl\+|CmdOrCtrl\+/g, "\u2318")
+      .replace(/Alt\+/g, "\u2325");
   }
   return shortcut
     .replace(/CommandOrControl\+|CmdOrCtrl\+/g, `${L10N.getStr("ctrl")}+`)


### PR DESCRIPTION
Fixes #7892

Here's the Pull Request Doc
https://firefox-dev.tools/debugger.html/docs/pull-requests.html

### Summary of Changes

* Removed spaces from formatKeyShortcut function for MacOS consistency

### Test Plan

1. I verified manually that the fix updated the shortcuts on the initial load of debugger
2. I run `yarn test` (Tests: 10 skipped, 1649 passed, 1659 total)