### PR TITLE
Remove postcss-bidirection

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -80,17 +80,11 @@ Set the `dir` field in the Launchpad's settings pane.
 
 _How do I change how something looks in rtl?_
 
-We use [postcss-bidirection][bidirection] to support [logical CSS][logical] properties. In practice, this means we can write `float:left` or `margin-inline-block: start`, and it just works. Under the hood, `float: left` gets translated into two different CSS rules for `html[dir="rtl"]` and `html:not([dir="rtl"])`.
-
-`public/js/components/SourceFooter.css`
+We use [logical CSS][logical] properties. For instance, if you need to add some padding-left in left-to-right layout and padding-right in right-to-left layout:
 
 ```css
-html:not([dir="rtl"]) .source-footer .command-bar {
-  float: right;
-}
-
-html[dir="rtl"] .source-footer .command-bar {
-  float: left;
+.my-component {
+  padding-inline-start: 10px;
 }
 ```
 
@@ -774,7 +768,6 @@ your questions on [Slack][slack].
 [create-local-config]: https://github.com/firefox-devtools/devtools-core/blob/master/packages/devtools-config/README.md#local-config
 [l10n-issues]: https://github.com/firefox-devtools/debugger.html/labels/localization
 [flow-issues]: https://github.com/firefox-devtools/debugger.html/labels/flow
-[bidirection]: https://github.com/gasolin/postcss-bidirection
 [logical]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties
 [scopes]: https://cloud.githubusercontent.com/assets/254562/22392764/019de6e6-e4cb-11e6-8445-2c4ec87cb4a6.png
 [call-stack]: https://cloud.githubusercontent.com/assets/254562/22392766/019eca70-e4cb-11e6-8b1a-e92b33a7cecb.png
@@ -795,7 +788,7 @@ your questions on [Slack][slack].
 [@jbhoosreddy]: https://github.com/jbhoosreddy
 [@arthur801031]: https://github.com/arthur801031
 [@zacqary]: https://github.com/zacqary
-[slack]: https://devtools-html-slack.herokuapp.com/
+[slack]: https://firefox-devtools-slack.herokuapp.com/
 [kill-strings]: https://github.com/firefox-devtools/devtools-core/issues/57
 [l10n]: https://github.com/firefox-devtools/devtools-core/blob/master/packages/devtools-launchpad/src/utils/L10N.js
 [rtl-screenshot]: https://cloud.githubusercontent.com/assets/394320/19226865/ef18b0d0-8eb9-11e6-82b4-8c4da702fe91.png

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -34,7 +34,6 @@ module.exports = ({ file, options, env }) => {
 
   return {
     plugins: [
-      require("postcss-bidirection"),
       require("autoprefixer")({
         browsers: ["last 2 Firefox versions", "last 2 Chrome versions"],
         flexbox: false,

--- a/src/components/ProjectSearch.css
+++ b/src/components/ProjectSearch.css
@@ -52,7 +52,7 @@
   padding-left: 5px;
   min-width: 33px;
   width: 100%;
-  text-align: right;
+  text-align: end;
   grid-column: 1/2;
 }
 

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -179,9 +179,7 @@ html .breakpoints-list .breakpoint.paused {
 }
 
 .breakpoint .close-btn {
-  offset-inline-end: 15px;
   inset-inline-end: 15px;
-  offset-inline-start: auto;
   inset-inline-start: auto;
   position: absolute;
   top: 8px;

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -131,11 +131,7 @@ html .breakpoints-list .breakpoint.paused {
   font-size: 11px;
   color: var(--theme-comment);
   min-width: 16px;
-  text-align: right;
-}
-
-html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
-  text-align: left;
+  text-align: end;
 }
 
 .breakpoints-list .breakpoint:hover .breakpoint-line {

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -37,10 +37,6 @@ html[dir="rtl"] .command-bar {
   color: var(--theme-highlight-blue);
 }
 
-.command-bar .subSettings {
-  float: right;
-}
-
 .command-bar .active .disable-pausing {
   background-color: var(--theme-icon-checked-color);
 }

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -94,7 +94,6 @@
 
 .expression-container__close-btn {
   position: absolute;
-  offset-inline-end: 0px;
   inset-inline-end: 0px;
   top: 1px;
 }

--- a/src/components/SecondaryPanes/XHRBreakpoints.css
+++ b/src/components/SecondaryPanes/XHRBreakpoints.css
@@ -109,8 +109,8 @@
 }
 
 .xhr-container__close-btn {
-  offset-inline-end: 12px;
-  offset-inline-start: auto;
+  inset-inline-end: 12px;
+  inset-inline-start: auto;
   position: absolute;
   top: 8px;
 }

--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -23,9 +23,7 @@
 .welcomebox .command-bar-button {
   position: absolute;
   top: auto;
-  offset-inline-end: 0;
   inset-inline-end: 0;
-  offset-inline-start: auto;
   inset-inline-start: auto;
   bottom: 0;
 }

--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -55,7 +55,7 @@
 }
 
 .shortcutKey {
-  text-align: right;
+  text-align: end;
   padding-right: 10px;
   font-family: var(--monospace-font-family);
   font-size: 14px;
@@ -64,7 +64,7 @@
 }
 
 .shortcutLabel {
-  text-align: left;
+  text-align: start;
   padding-left: 10px;
   font-size: 14px;
   line-height: 18px;

--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -9,7 +9,7 @@
   box-shadow: 0 4px 4px 0 var(--search-overlays-semitransparent);
   max-height: 300px;
   position: absolute;
-  offset-inline-end: 2px;
+  inset-inline-end: 2px;
   top: 24px;
   width: 150px;
   z-index: 1000;

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -34,7 +34,7 @@
 .search-field .img.search {
   position: absolute;
   z-index: 1;
-  left: 6px;
+  inset-inline: 6px;
   top: calc(50% - 8px);
   mask-size: 12px;
   background-color: var(--theme-icon-dimmed-color);
@@ -42,7 +42,7 @@
 }
 
 .search-field.big .img.search {
-  left: 12px;
+  inset-inline: 12px;
   mask-size: 16px;
 }
 

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -34,7 +34,7 @@
 .search-field .img.search {
   position: absolute;
   z-index: 1;
-  inset-inline: 6px;
+  inset-inline-start: 6px;
   top: calc(50% - 8px);
   mask-size: 12px;
   background-color: var(--theme-icon-dimmed-color);
@@ -42,7 +42,7 @@
 }
 
 .search-field.big .img.search {
-  inset-inline: 12px;
+  inset-inline-start: 12px;
   mask-size: 16px;
 }
 


### PR DESCRIPTION
Fixes #7941

* Remove postcss-bidirection from `postcss.config.js`
* Fix the RTL magnifying glass icon position in RTL
* Change a few text-align values to start|end

I've tested a few things and things look alright in Chrome and Firefox.
More hands on testing would be welcome though. (We may find RTL issues that already exist on master, by the way.)
