### PR TITLE
Modified the Angular regex

### DIFF
--- a/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/utils/pause/frames/getLibraryFromUrl.js
@@ -78,7 +78,13 @@ const libraryMap = [
   },
   {
     label: "Angular",
-    pattern: /angular\.|angular.*(animations|common|core|elements|forms|platform-browser|platform-server|platform-webworker|router|service-worker|upgrade)/i,
+    pattern: new RegExp(
+      "angular\\.|" +
+        "angular.*" +
+        "(animations|common|core|elements|forms|platform-browser|" +
+        "platform-server|platform-webworker|router|service-worker|upgrade)",
+      "i"
+    ),
     contextPattern: /(zone\.js)/
   },
   {

--- a/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/utils/pause/frames/getLibraryFromUrl.js
@@ -78,7 +78,7 @@ const libraryMap = [
   },
   {
     label: "Angular",
-    pattern: /angular.*core/i,
+    pattern: /@angular\//,
     contextPattern: /(zone\.js)/
   },
   {

--- a/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/utils/pause/frames/getLibraryFromUrl.js
@@ -78,7 +78,7 @@ const libraryMap = [
   },
   {
     label: "Angular",
-    pattern: /@angular\//,
+    pattern: /@angular\/|angular\.js/,
     contextPattern: /(zone\.js)/
   },
   {

--- a/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/utils/pause/frames/getLibraryFromUrl.js
@@ -78,13 +78,7 @@ const libraryMap = [
   },
   {
     label: "Angular",
-    pattern: new RegExp(
-      "angular\\.|" +
-        "angular.*" +
-        "(animations|common|core|elements|forms|platform-browser|" +
-        "platform-server|platform-webworker|router|service-worker|upgrade)",
-      "i"
-    ),
+    pattern: /angular(?!.*\/app\/)/i,
     contextPattern: /(zone\.js)/
   },
   {

--- a/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/utils/pause/frames/getLibraryFromUrl.js
@@ -78,7 +78,7 @@ const libraryMap = [
   },
   {
     label: "Angular",
-    pattern: /angular/i,
+    pattern: /angular.*core/i,
     contextPattern: /(zone\.js)/
   },
   {

--- a/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/utils/pause/frames/getLibraryFromUrl.js
@@ -78,7 +78,7 @@ const libraryMap = [
   },
   {
     label: "Angular",
-    pattern: /@angular\/|angular\.js/,
+    pattern: /angular\.|angular.*(animations|common|core|elements|forms|platform-browser|platform-server|platform-webworker|router|service-worker|upgrade)/i,
     contextPattern: /(zone\.js)/
   },
   {

--- a/src/utils/pause/frames/tests/annotateFrames.spec.js
+++ b/src/utils/pause/frames/tests/annotateFrames.spec.js
@@ -15,7 +15,7 @@ describe("annotateFrames", () => {
       ),
       makeMockFrameWithURL("/node_modules/zone/zone.js"),
       makeMockFrameWithURL(
-        "https://stackblitz.io/turbo_modules/@angular/core@7.2.4/bundles/core.umd.js"
+        "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
       )
     ];
     const frames = annotateFrames(callstack);

--- a/src/utils/pause/frames/tests/annotateFrames.spec.js
+++ b/src/utils/pause/frames/tests/annotateFrames.spec.js
@@ -11,11 +11,11 @@ describe("annotateFrames", () => {
   it("should return Angular", () => {
     const callstack = [
       makeMockFrameWithURL(
-        "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
+        "https://stackblitz.io/turbo_modules/@angular/core@7.2.4/bundles/core.umd.js"
       ),
       makeMockFrameWithURL("/node_modules/zone/zone.js"),
       makeMockFrameWithURL(
-        "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
+        "https://stackblitz.io/turbo_modules/@angular/core@7.2.4/bundles/core.umd.js"
       )
     ];
     const frames = annotateFrames(callstack);

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -71,17 +71,23 @@ describe("getLibraryFromUrl", () => {
 
   describe("When Angular is in the URL", () => {
     it("should return Angular for AngularJS (1.x)", () => {
-      const frame = makeMockFrameWithURL("https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js");
+      const frame = makeMockFrameWithURL(
+        "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
+      );
       expect(getLibraryFromUrl(frame)).toEqual("Angular");
     });
 
     it("should return Angular for Angular (2.x)", () => {
-      const frame = makeMockFrameWithURL("https://stackblitz.io/turbo_modules/@angular/core@7.2.4/bundles/core.umd.js");
+      const frame = makeMockFrameWithURL(
+        "https://stackblitz.io/turbo_modules/@angular/core@7.2.4/bundles/core.umd.js"
+      );
       expect(getLibraryFromUrl(frame)).toEqual("Angular");
     });
 
     it("should not return Angular for Angular components", () => {
-      const frame = makeMockFrameWithURL("https://firefox-devtools-angular-log.stackblitz.io/~/src/app/hello.component.ts");
+      const frame = makeMockFrameWithURL(
+        "https://firefox-devtools-angular-log.stackblitz.io/~/src/app/hello.component.ts"
+      );
       expect(getLibraryFromUrl(frame)).toBeNull();
     });
   });

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -87,7 +87,7 @@ describe("getLibraryFromUrl", () => {
       const callstack = [
         frame,
         makeMockFrameWithURL(
-          "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
+          "https://stackblitz.io/turbo_modules/@angular/core@7.2.4/bundles/core.umd.js"
         )
       ];
 

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -69,6 +69,23 @@ describe("getLibraryFromUrl", () => {
     });
   });
 
+  describe("When Angular is in the URL", () => {
+    it("should return Angular for AngularJS (1.x)", () => {
+      const frame = makeMockFrameWithURL("https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js");
+      expect(getLibraryFromUrl(frame)).toEqual("Angular");
+    });
+
+    it("should return Angular for Angular (2.x)", () => {
+      const frame = makeMockFrameWithURL("https://stackblitz.io/turbo_modules/@angular/core@7.2.4/bundles/core.umd.js");
+      expect(getLibraryFromUrl(frame)).toEqual("Angular");
+    });
+
+    it("should not return Angular for Angular components", () => {
+      const frame = makeMockFrameWithURL("https://firefox-devtools-angular-log.stackblitz.io/~/src/app/hello.component.ts");
+      expect(getLibraryFromUrl(frame)).toBeNull();
+    });
+  });
+
   describe("When zone.js is on the frame", () => {
     it("should not return Angular when no callstack", () => {
       const frame = makeMockFrameWithURL("/node_modules/zone/zone.js");
@@ -82,12 +99,12 @@ describe("getLibraryFromUrl", () => {
       expect(getLibraryFromUrl(frame, callstack)).toEqual(null);
     });
 
-    it("should return Angular when stack with Angular frames", () => {
+    it("should return Angular when stack with AngularJS (1.x) frames", () => {
       const frame = makeMockFrameWithURL("/node_modules/zone/zone.js");
       const callstack = [
         frame,
         makeMockFrameWithURL(
-          "https://stackblitz.io/turbo_modules/@angular/core@7.2.4/bundles/core.umd.js"
+          "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
         )
       ];
 

--- a/test/mochitest/browser_dbg-call-stack.js
+++ b/test/mochitest/browser_dbg-call-stack.js
@@ -39,7 +39,7 @@ function createMockAngularPage() {
 
   // Register an angular.js file in order to create a Group with anonymous functions in
   // the callstack panel.
-  httpServer.registerPathHandler("@angular/core@7.2.4/bundles/core.umd.js", function(request, response) {
+  httpServer.registerPathHandler("/@angular/core@7.2.4/bundles/core.umd.js", function(request, response) {
     response.setHeader("Content-Type", "application/javascript");
     response.write(`
       document.querySelector("button.pause").addEventListener("click", () => {

--- a/test/mochitest/browser_dbg-call-stack.js
+++ b/test/mochitest/browser_dbg-call-stack.js
@@ -31,7 +31,7 @@ function createMockAngularPage() {
       response.write(`
         <html>
             <button class="pause">Click me</button>
-            <script type="text/javascript" src="@angular/core@7.2.4/bundles/core.umd.js"></script>
+            <script type="text/javascript" src="angular.js"></script>
         </html>`
       );
     }
@@ -39,7 +39,7 @@ function createMockAngularPage() {
 
   // Register an angular.js file in order to create a Group with anonymous functions in
   // the callstack panel.
-  httpServer.registerPathHandler("/@angular/core@7.2.4/bundles/core.umd.js", function(request, response) {
+  httpServer.registerPathHandler("/angular.js", function(request, response) {
     response.setHeader("Content-Type", "application/javascript");
     response.write(`
       document.querySelector("button.pause").addEventListener("click", () => {

--- a/test/mochitest/browser_dbg-call-stack.js
+++ b/test/mochitest/browser_dbg-call-stack.js
@@ -31,7 +31,7 @@ function createMockAngularPage() {
       response.write(`
         <html>
             <button class="pause">Click me</button>
-            <script type="text/javascript" src="angular.js"></script>
+            <script type="text/javascript" src="@angular/core@7.2.4/bundles/core.umd.js"></script>
         </html>`
       );
     }
@@ -39,7 +39,7 @@ function createMockAngularPage() {
 
   // Register an angular.js file in order to create a Group with anonymous functions in
   // the callstack panel.
-  httpServer.registerPathHandler("/angular.js", function(request, response) {
+  httpServer.registerPathHandler("@angular/core@7.2.4/bundles/core.umd.js", function(request, response) {
     response.setHeader("Content-Type", "application/javascript");
     response.write(`
       document.querySelector("button.pause").addEventListener("click", () => {


### PR DESCRIPTION
Fixes #7901

### Summary of Changes

Modified `getLibraryFromUrl()` so that it only matches Angular's core framework sub folder, not its components.
- Matches `/turbo_modules/@angular/core@7.0.1/bundles/core.umd.js`
- Doesn't match `/~/src/app/hello.component.ts`


Note that in the image below, `ngOnInit` (which is defined in hello.component.ts) isn't collapsed into the Angular frame group:

<img width="387" alt="screen shot 2019-02-13 at 9 35 38 am" src="https://user-images.githubusercontent.com/15959269/52719301-61333080-2f73-11e9-8214-d41da12eb9c7.png">
