### PR TITLE
Ensure consistent filenames throughout tabs, tree, and search

### DIFF
--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -213,7 +213,7 @@ class SourceTreeItem extends Component<Props, State> {
       case "webpack://":
         return "Webpack";
       default:
-        return `${item.name}`;
+        return `${unescape(item.name)}`;
     }
   }
 

--- a/src/components/PrimaryPanes/tests/SourcesTreeItem.spec.js
+++ b/src/components/PrimaryPanes/tests/SourcesTreeItem.spec.js
@@ -337,6 +337,17 @@ describe("SourceTreeItem", () => {
       component.simulate("click", { event: "click" });
       expect(props.selectItem).not.toHaveBeenCalled();
     });
+
+    it("should unescape escaped source URLs", async () => {
+      const item = createMockItem({
+        path: "mdn.com/external%20file",
+        name: "external%20file"
+      });
+
+      const node = render({ item });
+
+      expect(node).toMatchSnapshot();
+    });
   });
 });
 

--- a/src/components/PrimaryPanes/tests/__snapshots__/SourcesTreeItem.spec.js.snap
+++ b/src/components/PrimaryPanes/tests/__snapshots__/SourcesTreeItem.spec.js.snap
@@ -2271,3 +2271,225 @@ Object {
   },
 }
 `;
+
+exports[`SourceTreeItem renderItem should unescape escaped source URLs 1`] = `
+Object {
+  "component": <div
+    className="node"
+    key="mdn.com/external%20file"
+    onClick={[Function]}
+    onContextMenu={[Function]}
+  >
+    <span
+      className="img no-arrow"
+    />
+    <Connect(SourceIcon)
+      source={
+        Object {
+          "contentType": "",
+          "error": undefined,
+          "id": "server1.conn13.child1/39",
+          "isBlackBoxed": false,
+          "isExtension": false,
+          "isPrettyPrinted": false,
+          "isWasm": false,
+          "loadedState": "unloaded",
+          "sourceMapURL": undefined,
+          "text": undefined,
+          "url": "http://mdn.com/one.js",
+        }
+      }
+    />
+    <span
+      className="label"
+    >
+       
+      external file
+       
+    </span>
+  </div>,
+  "defaultState": null,
+  "instance": SourceTreeItem {
+    "addCollapseExpandAllOptions": [Function],
+    "context": Object {},
+    "onClick": [Function],
+    "onContextMenu": [Function],
+    "props": Object {
+      "clearProjectDirectoryRoot": [MockFunction],
+      "debuggeeUrl": "http://mdn.com",
+      "expanded": false,
+      "focusItem": [MockFunction],
+      "item": Object {
+        "contents": Object {
+          "contentType": "",
+          "error": undefined,
+          "id": "server1.conn13.child1/39",
+          "isBlackBoxed": false,
+          "isExtension": false,
+          "isPrettyPrinted": false,
+          "isWasm": false,
+          "loadedState": "unloaded",
+          "sourceMapURL": undefined,
+          "text": undefined,
+          "url": undefined,
+        },
+        "name": "external%20file",
+        "path": "mdn.com/external%20file",
+        "type": "source",
+      },
+      "projectRoot": "",
+      "selectItem": [MockFunction],
+      "setExpanded": [MockFunction],
+      "setProjectDirectoryRoot": [MockFunction],
+      "source": Object {
+        "contentType": "",
+        "error": undefined,
+        "id": "server1.conn13.child1/39",
+        "isBlackBoxed": false,
+        "isExtension": false,
+        "isPrettyPrinted": false,
+        "isWasm": false,
+        "loadedState": "unloaded",
+        "sourceMapURL": undefined,
+        "text": undefined,
+        "url": "http://mdn.com/one.js",
+      },
+      "toggleBlackBox": [MockFunction],
+    },
+    "refs": Object {},
+    "state": null,
+    "updater": Updater {
+      "_callbacks": Array [],
+      "_renderer": ReactShallowRenderer {
+        "_context": Object {},
+        "_element": <SourceTreeItem
+          clearProjectDirectoryRoot={[MockFunction]}
+          debuggeeUrl="http://mdn.com"
+          expanded={false}
+          focusItem={[MockFunction]}
+          item={
+            Object {
+              "contents": Object {
+                "contentType": "",
+                "error": undefined,
+                "id": "server1.conn13.child1/39",
+                "isBlackBoxed": false,
+                "isExtension": false,
+                "isPrettyPrinted": false,
+                "isWasm": false,
+                "loadedState": "unloaded",
+                "sourceMapURL": undefined,
+                "text": undefined,
+                "url": undefined,
+              },
+              "name": "external%20file",
+              "path": "mdn.com/external%20file",
+              "type": "source",
+            }
+          }
+          projectRoot=""
+          selectItem={[MockFunction]}
+          setExpanded={[MockFunction]}
+          setProjectDirectoryRoot={[MockFunction]}
+          source={
+            Object {
+              "contentType": "",
+              "error": undefined,
+              "id": "server1.conn13.child1/39",
+              "isBlackBoxed": false,
+              "isExtension": false,
+              "isPrettyPrinted": false,
+              "isWasm": false,
+              "loadedState": "unloaded",
+              "sourceMapURL": undefined,
+              "text": undefined,
+              "url": "http://mdn.com/one.js",
+            }
+          }
+          toggleBlackBox={[MockFunction]}
+        />,
+        "_forcedUpdate": false,
+        "_instance": [Circular],
+        "_newState": null,
+        "_rendered": <div
+          className="node"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+        >
+          <span
+            className="img no-arrow"
+          />
+          <Connect(SourceIcon)
+            source={
+              Object {
+                "contentType": "",
+                "error": undefined,
+                "id": "server1.conn13.child1/39",
+                "isBlackBoxed": false,
+                "isExtension": false,
+                "isPrettyPrinted": false,
+                "isWasm": false,
+                "loadedState": "unloaded",
+                "sourceMapURL": undefined,
+                "text": undefined,
+                "url": "http://mdn.com/one.js",
+              }
+            }
+          />
+          <span
+            className="label"
+          >
+             
+            external file
+             
+          </span>
+        </div>,
+        "_rendering": false,
+        "_updater": [Circular],
+      },
+    },
+  },
+  "props": Object {
+    "clearProjectDirectoryRoot": [MockFunction],
+    "debuggeeUrl": "http://mdn.com",
+    "expanded": false,
+    "focusItem": [MockFunction],
+    "item": Object {
+      "contents": Object {
+        "contentType": "",
+        "error": undefined,
+        "id": "server1.conn13.child1/39",
+        "isBlackBoxed": false,
+        "isExtension": false,
+        "isPrettyPrinted": false,
+        "isWasm": false,
+        "loadedState": "unloaded",
+        "sourceMapURL": undefined,
+        "text": undefined,
+        "url": undefined,
+      },
+      "name": "external%20file",
+      "path": "mdn.com/external%20file",
+      "type": "source",
+    },
+    "projectRoot": "",
+    "selectItem": [MockFunction],
+    "setExpanded": [MockFunction],
+    "setProjectDirectoryRoot": [MockFunction],
+    "source": Object {
+      "contentType": "",
+      "error": undefined,
+      "id": "server1.conn13.child1/39",
+      "isBlackBoxed": false,
+      "isExtension": false,
+      "isPrettyPrinted": false,
+      "isWasm": false,
+      "loadedState": "unloaded",
+      "sourceMapURL": undefined,
+      "text": undefined,
+      "url": "http://mdn.com/one.js",
+    },
+    "toggleBlackBox": [MockFunction],
+  },
+}
+`;

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -19,7 +19,7 @@ export function getFilenameFromPath(pathname?: string) {
   if (pathname) {
     filename = pathname.substring(pathname.lastIndexOf("/") + 1);
     // This file does not have a name. Default should be (index).
-    if (filename == "" || !filename.includes(".")) {
+    if (filename == "") {
       filename = "(index)";
     }
   }

--- a/src/utils/sources-tree/tests/getUrl.spec.js
+++ b/src/utils/sources-tree/tests/getUrl.spec.js
@@ -56,10 +56,20 @@ describe("getUrl", () => {
     expect(urlObject.filename).toBe("b.js");
   });
 
-  it("handles url with no filename for filename", function() {
+  it("handles url with no file extension for filename", function() {
     const urlObject = getURL(
       createMockSource({
         url: "https://a/c",
+        id: "c"
+      })
+    );
+    expect(urlObject.filename).toBe("c");
+  });
+
+  it("handles url with no name for filename", function() {
+    const urlObject = getURL(
+      createMockSource({
+        url: "https://a/",
         id: "c"
       })
     );


### PR DESCRIPTION
I noticed when going to https://w2x2oypmqk.codesandbox.io/ that the sources tree cited "external%20file" but, when opened, the tab said "(index)", as did a sources search.

Simply checking for no "." is far too basic.

<img width="995" alt="yaysame" src="https://user-images.githubusercontent.com/46655/52745980-167edc00-2fa6-11e9-9cb9-9a2258e374ab.png">

I've also unescaped the text in the tree, as it used to be.