### PR TITLE
Fix Bugzilla 1108132 - Provide code wrapping pref for debugger

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -26,6 +26,7 @@ pref("devtools.debugger.ui.variables-sorting-enabled", true);
 pref("devtools.debugger.ui.variables-only-enum-visible", false);
 pref("devtools.debugger.ui.variables-searchbox-visible", false);
 pref("devtools.debugger.ui.framework-grouping-on", true);
+pref("devtools.debugger.ui.editor-wrapping", false);
 pref("devtools.debugger.call-stack-visible", true);
 pref("devtools.debugger.scopes-visible", true);
 pref("devtools.debugger.component-visible", true);

--- a/src/utils/editor/create-editor.js
+++ b/src/utils/editor/create-editor.js
@@ -5,7 +5,7 @@
 // @flow
 
 import SourceEditor from "./source-editor";
-import { features } from "../prefs";
+import { features, prefs } from "../prefs";
 
 export function createEditor() {
   const gutters = ["breakpoints", "hit-markers", "CodeMirror-linenumbers"];
@@ -22,7 +22,7 @@ export function createEditor() {
     lineNumbers: true,
     theme: "mozilla",
     styleActiveLine: false,
-    lineWrapping: false,
+    lineWrapping: prefs.editorWrapping,
     matchBrackets: true,
     showAnnotationRuler: true,
     gutters,

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -36,6 +36,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.end-panel-size", 300);
   pref("devtools.debugger.tabs", "[]");
   pref("devtools.debugger.tabsBlackBoxed", "[]");
+  pref("devtools.debugger.ui.editor-wrapping", false);
   pref("devtools.debugger.ui.framework-grouping-on", true);
   pref("devtools.debugger.pending-selected-location", "{}");
   pref("devtools.debugger.pending-breakpoints", "{}");
@@ -71,6 +72,7 @@ if (isDevelopment()) {
 
 export const prefs = new PrefsHelper("devtools", {
   logging: ["Bool", "debugger.logging"],
+  editorWrapping: ["Bool", "debugger.ui.editor-wrapping"],
   alphabetizeOutline: ["Bool", "debugger.alphabetize-outline"],
   autoPrettyPrint: ["Bool", "debugger.auto-pretty-print"],
   clientSourceMapsEnabled: ["Bool", "source-map.client-service.enabled"],


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1108132

Wanting code to be wrapped seems completely reasonable to me -- I sometimes do it in my local text editor.

We could consider providing a UI for this in the settings pane or even a toggle-able checkbox in the Editor footer.