### PR TITLE
Switch expressions delete button

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -99,6 +99,22 @@
   top: 1px;
 }
 
+.expression-container .close-btn {
+  display: none;
+}
+
+.expression-container:focus-within .close-btn {
+  display: flex;
+}
+
+.expression-container .close {
+  visibility: hidden;
+}
+
+.expression-container:focus-within .close {
+  visibility: visible;
+}
+
 .expression-content {
   position: relative;
 }


### PR DESCRIPTION
Fixes #<#7868>

Hi, I read your comment about the concern of accessibility in #7868. Based on Harald's suggestion, I used 'focus-within.' But with that, a user using a mouse needs to click in the expression container so that the delete button displays; hovering the expression doesn't display the delete button. When moving the mouse out of the container, the delete button doesn't disappear. We need to click somewhere else to make the container to lose focus.

This behavior is inconsistent with breakpoint's. If I replace 'focus-within' with 'hover,' it will behave the same as breakpoints. 

I think no matter which one we choose, it's better to make it consistent for both expressions and breakpoints. Let me know what you think.

### Summary of Changes
* Added display property
* Added visibility property

### Test Plan
- Add watch expression
- Click on the expression container
- Move mouse out of the container
- Click somewhere to turn off 'focus-within'

### Screenshots
http://g.recordit.co/dEXtmKef1C.gif