### PR TITLE
Update mochitests docs

### DIFF
--- a/assets/dictionary.txt
+++ b/assets/dictionary.txt
@@ -208,3 +208,7 @@ asyncStore
 CPG
 TodoMVC
 pseudocode
+TravisCI
+30-60minutes
+myScriptFunction
+Homebrew

--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -25,7 +25,7 @@ Simply put, its tests simulate what you expect a user to do, and then check that
 
 Typically, tests would simulate a user's action flow through the debugger _(e.g. click this button, press this key)_. After performing a set of actions, we set assertions _(e.g. debugger is paused/not paused, elements appear/disappear)_.
 
-[A typical test workflow would look like this.](http://g.recordit.co/dp6qbK0Jnf.gif).
+[A typical test workflow would look like this.](http://g.recordit.co/dp6qbK0Jnf.gif)
 
 ## Initial Setup ##
 

--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -25,6 +25,8 @@ Simply put, its tests simulate what you expect a user to do, and then check that
 
 Typically, tests would simulate a user's action flow through the debugger _(e.g. click this button, press this key)_. After performing a set of actions, we set assertions _(e.g. debugger is paused/not paused, elements appear/disappear)_.
 
+[A typical test workflow would look like this.](http://g.recordit.co/dp6qbK0Jnf.gif).
+
 ## Initial Setup ##
 
 ### Mac ###

--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -1,60 +1,341 @@
 ## Mochitests
 
-- [Getting Started](#getting-started)
+Mochitests is a test runner for integration (end-to-end) testing that allows us to test the debugger literally as a user would use it natively.
+
+It is different from other test runners (Jest, Mocha, Jasmine) because it simulates a real user interacting with your application. For debugger.html, we do this by building your own version of Firefox with your changes to debugger.html. This Firefox build and its debugger is what's tested by Mochitests, in the same way that a user interacting with the debugger would natively.
+
+If you've submitted a pull request to this project, you've already worked with Mochitests! TravisCI, which is one of the checks your PR has to pass, runs Mochitests every time you push a new commit to your PR.
+
+- [What does Mochitests do](#what-does-mochitests-do)
+- [Initial Setup](#initial-setup)
 - [Running the tests](#running-the-tests)
-- [Mochi](#mochi)
-- [Writing Tests](#writing-tests)
+- [Folder Overview](#folder-overview)
+- [Writing tests](#writing-tests)
+- [Your First Test](#your-first-test)
+- [Debugging your tests](#debugging-your-tests)
+- [Test Writing Tips](#test-writing-tips)
+- [Adding New Test Files](#adding-new-test-files)
 - [Debugging Intermittents](#debugging-intermittents)
-- [Troubleshooting Test Harness](#troubleshooting-test-harness)
-  - [Missing Rust compiler](#missing-rust-compiler)
+- [Videos](#videos)
+- [Appendix](#appendix)
 
-We use [mochitests] to do integration testing. Mochitests are part of Firefox and allow us to test the debugger literally as you would use it (as a devtools panel).
+## What does Mochitests do? ##
 
-Mochitests are different from Jest, Mocha, Selenium, because we have access to firefox internals and run inside the browser toolbox. This makes it possible to write tests as if we're a user interacting with the debugger natively :)
+Simply put, its tests simulate what you expect a user to do, and then check that the expected debugger behavior happens.
 
-![](http://g.recordit.co/dp6qbK0Jnf.gif)
+Typically, tests would simulate a user's action flow through the debugger _(e.g. click this button, press this key)_. After performing a set of actions, we set assertions _(e.g. debugger is paused/not paused, elements appear/disappear)_.
 
-### Getting Started
+## Initial Setup ##
 
-**Requirements**
+### Mac ###
 
-- mercurial ( `brew install mercurial` )
-- autoconf213 ( `brew install autoconf@2.13 && brew unlink autoconf` )
-
-**Setup Firefox**
-
-- Inside the main debugger.html folder run:
-
+Before starting, make sure you have the most updated versions of [Homebrew](https://brew.sh/) and [Python](https://www.python.org/downloads/). Afterwards, run the following from inside the main `debugger.html` folder:
 ```
+brew install mercurial
+brew install autoconf@2.13 && brew unlink autoconf
 ./bin/prepare-mochitests-dev
 ```
 
-This command will either clone `mozilla-central` (the firefox repo) or update it.
-It also sets up a symlink for the tests so that changes in `test/mochitest` are
-reflected in the new firefox directory.
+On your first setup, `./bin/prepare-mochitests-dev` clones Firefox's repository (`mozilla-central`). Downloading all of Firefox's source files may take ~30-60 minutes depending on your internet connection.
 
-### Running the tests
+After your initial setup, running `./bin/prepare-mochitests-dev` updates the cloned Firefox repository.
 
-- `yarn watch` copies new bundles into the firefox directory
-- `yarn mochi` runs the tests in a second process
+### Windows ###
 
-### Mochi
+The detailed instructions for setting up your environment to build Firefox for Windows can be found [here](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites). Make sure to follow the steps under the sections **Getting ready**, **Visual Studio 2017** and **Required tools**.
 
-`mochi` passes its params along to `mochitest`, so you can include `--jsdebugger` and test globs
+Afterwards, you can open a unix-flavor shell by starting:
 
-- `yarn mochi dbg-editor-highlight` runs just one test
-- `yarn mochid dbg-editor-highlight` opens a browser toolbox
-- `yarn mochih dbg-editor-highlight` runs the test headlessly
+```
+C:\mozilla-build\start-shell.bat
+```
 
-## Writing Tests
+In the shell, navigate to the Debugger.html project folder. On your first setup, `./bin/prepare-mochitests-dev` clones Firefox's repository (`mozilla-central`). Downloading all of Firefox's source files may take ~30-60minutes depending on your internet connection.
 
-Here are a few tips for writing mochitests:
+After your initial setup, running `./bin/prepare-mochitests-dev` updates the cloned Firefox repository.
 
-- There are lots of great helper methods in [head]
-- Try to write async user actions that involve a user action like clicking a button or typing a key press followed by a redux action to listen for. For example, the user step in action involves the user clicking the step in button followed by the "stepIn" action firing.
-- The `dbg` object has several helpful properties (actions, selectors, getState, store, toolbox, win)
+## Running the tests ##
 
-### Videos
+> NOTE: Make sure you have [Yarn](https://yarnpkg.com/) installed before proceeding with the following steps
+
+Every time you want to run your tests, the Firefox clone needs to be rebuilt with your updated local debugger.html. To do that, run the following:
+
+```
+yarn copy
+./firefox/mach build
+```
+
+After rebuilding Firefox, you are ready to run your tests! There are three options:
+```
+// 1) Run the tests on your Firefox clone **without pausing** on debugger statements:
+yarn mochi
+
+// 2) Run the tests on your Firefox clone **with pausing** on debugger statements:
+yarn mochid
+
+// 3) Run the tests on your Firefox clone **headlessly without pausing** on debugger statements:
+yarn mochih
+```
+
+The commands above will run **all** of your tests. If you want to only run one test, you can specify a test you want to run by adding its pattern. For example, if you want to run the test `browser_dbg-tabs-keyboard.js` headlessly, you would run `yarn mochih tabs-keyboard`.
+
+A common testing workflow is 1) editing the test or the debugger code and 2) wanting to check whether a specific test passes. A common script to run for that scenario is `yarn copy && ./firefox/mach build && yarn mochih your-test-name-here`. This copies your debugger, rebuilds Firefox and runs your test all in one go.
+
+> NOTE: While running `yarn mochi` or `yarn mochid`, keep focus on the browser window while the tests are being run
+
+## Folder Overview ##
+All relevant Mochitest files are in `tests/mochitests`. A quick glance reveals the following:
+
+* test files are all prefixed with `browser_dbg-`
+* test runner helper functions are contained within `helpers.js`
+* source files to be loaded by debugger test instances are in the folder `examples/`
+
+## Writing tests ##
+Each individual test has the following structure in common - `add_task()` is provided with an async function in which the debugger is initialized:
+
+```js
+add_task(async function() {
+  const dbg = await initDebugger("page-to-be-loaded.html");
+
+  /* Your test here */
+
+});
+```
+
+Sometimes, your `page-to-be-loaded.html` may rely on external scripts. In that case, it's good practice to provide those sources to `initDebugger()` so that it knows to wait for those sources to be loaded before finishing the initialization.
+
+```js
+add_task(async function() {
+  const dbg = await initDebugger("page-to-be-loaded.html", "source.js", "another-source.js");
+
+  /* Your test here */
+
+});
+```
+
+> NOTE: The root directory for any relative URL specified is `test/mochitest/examples`
+
+## Your First Test ##
+At its core, what Mochitest does is it simulates a **user action**, like a mouse click on an element, and checks whether the **expected behavior** happens. Take for example the expand/collapse behavior of the Watch Expressions pane upon clicking its header:
+
+1. By default, the Watch Expression pane is expanded
+2. If we click on the Watch Expressions header, we expect the Watch Expression pane to collapse i.e. "content" is hidden
+3. If we click on the Watch Expressions header again, we expect the Watch Expression pane to expand i.e. "content" is displayed
+
+For illustration purposes, the structure of the Watch Expression pane element looks like this:
+
+```html
+<li class="watch-expressions-pane">
+  <h2 class = "_header">...</h2>
+  <div class = "_content">...</div>
+</li>
+```
+
+We might then write that test like this:
+
+```js
+add_task(async function() {
+  const dbg = await initDebugger("doc-watch-expressions.html");
+
+  // 1) Check whether Watch Expressions pane is expanded
+  var watchExpressionsContent = findElementWithSelector(dbg, ".watch-expressions-pane ._content");
+  ok(watchExpressionsContent === true, "watch expressions content is displayed")
+
+  // 2) Click on the header to collapse the pane. Check that it's collapsed
+  const watchExpressionsHeader = findElementWithSelector(dbg, ".watch-expressions-pane ._header");
+  watchExpressionsHeader.click();
+  watchExpressionsContent = findElementWithSelector(dbg, ".watch-expressions-pane ._content");
+  ok(watchExpressionsContent === false, "watch expressions content is not displayed")
+
+  // 3) Click on the header again to expand the pane. Check that it's expanded
+  watchExpressionsHeader.click();
+  watchExpressionsContent = findElementWithSelector(dbg, ".watch-expressions-pane ._content");
+  ok(watchExpressionsContent === true, "watch expressions content is displayed")
+});
+```
+
+While this is a simple example, most of the Mochitests you will encounter follow the same process. What's important in writing them is to know clearly the actions you expect the user to do, how the debugger should behave in response to those actions, and insert assertions to test those behaviors.
+
+In this example, we use a few helper functions that you may not be familiar with yet. These helper functions are all in [`test/mochitest/helpers.js`](https://github.com/firefox-devtools/debugger.html/blob/4a1622ae7d2230e79cae049ae0e95db7960c2cc7/test/mochitest/helpers.js), and for the most part are just variants on concepts you probably already know. For example, `findElementWithSelector()` is simply a wrapper for `document.querySelector()` specifically for your debugger instance.
+
+## Debugging your tests
+While working on your tests, you might find that they're not running the way you expect them to. There are a few ways to figure out what exactly is happening and we will list them out here.
+
+### 1) Read the logs
+The first step for debugging an integration test is establishing a clear sequence of events: where did the test break and what were the events that happened before it broke. The Mochitests logs are a valuable source of information in providing this context. A quick glance at the logs may provide you with enough information to figure out what's gone wrong. These include:
+
+* Actions that fired
+* Assertions that passed/failed
+* Events that the test waited for (e.g. dispatches, state changes)
+
+We like to add additional logging in the test and debugger code with `info()` calls, which is similar to `console.log()`. Where necessary, use [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) with expressions to make `info()` calls as informative as possible.
+
+* `info("Adding an expression")`
+* `` info(`Thread event '${eventName}' fired.`) ``
+* `` info(`Waiting for ${type} to dispatch ${eventRepeat} time(s)`) ``
+
+It's worth noting that any `console.log()` statements in non-test code that runs in the debugger (e.g. React Component code) does not get outputted to the terminal. This is because those `console.log()` calls print their logs on the test browser console instead. If you need to print something to the terminal from non-test code, use `dump()` calls instead which functions similarly to `console.log()`
+
+### 2) Freezing the debugger
+Sometimes you might want to stop the test execution to see what's going on.
+
+In that case you can insert an `await waitForever()` within your test. This doesn't technically pause the debugger, but it stops the test execution all the same because the promise never gets resolved. This allows you to see what the DOM looks like at that point in time or inspect things via the debugger/console.
+
+```js
+add_task(async function() {
+  const dbg = await initDebugger("doc-watch-expressions.html");
+  var watchExpressionsContent = findElementWithSelector(dbg, ".watch-expressions-pane ._content");
+
+  // Stop the test here to inspect the DOM and see whether content really is displayed
+  await waitForever();
+
+  ok(watchExpressionsContent === true, "watch expressions content is displayed")
+});
+```
+
+A similar alternative is to use `await waitForTime(ms)` which takes a millisecond(`ms`) value to wait for, instead of waiting indefinitely.
+
+### 3) Pausing the debugger
+To pause the debugger, you need to put a `debugger` statement within your tests.
+
+```js
+add_task(async function() {
+  const dbg = await initDebugger("doc-watch-expressions.html");
+  var watchExpressionsContent = findElementWithSelector(dbg, ".watch-expressions-pane ._content");
+
+  // Pause the test here and use the debugger to look around
+  debugger;
+
+  ok(watchExpressionsContent === true, "watch expressions content is displayed")
+});
+```
+
+This `debugger` statements is paused at **only** when you run the mochitests in debugger mode (`yarn mochid your-test-here`). While debugging with `yarn mochid`, a separate browser toolbox is opened from which you can debug the test that is currently running. While you can set breakpoints in this mode, they're not paused at - only inline `debugger` statements are paused at.
+
+Note that these `debugger` statements are not limited to test code. They are also paused at in non-test code, which you can try by adding a `debugger` statement to a relevant React component of a test you will be running with `yarn mochid`.
+
+## Test Writing Tips ##
+By now, you should have a good grasp of the basic concepts of testing with Mochitests.
+
+At this point, it's worth taking some time to become familiar with the helper methods in [helpers.js](https://github.com/firefox-devtools/debugger.html/blob/4a1622ae7d2230e79cae049ae0e95db7960c2cc7/test/mochitest/helpers.js). Below, we list some common patterns that come up while testing, and "best practices" for how to deal with them using the helper methods.
+
+### Waiting in a test
+It's common to want to wait for something to happen in a test. Generally we wait for one of two things to happen:
+
+1. Waiting for the Redux state to change
+
+```js
+add_task(async function() {
+  const dbg = await initDebugger("doc-sourcemaps.html", "entry.js");
+  const entrySrc = findSource(dbg, "entry.js");
+
+  await addBreakpoint(dbg, entrySrc, 5);
+  await addBreakpoint(dbg, entrySrc, 13);
+  await addBreakpoint(dbg, entrySrc, 15);
+
+  // We use waitForState() here to make sure that our predicate function returns true before the is() assertion
+  await waitForState(dbg, state => dbg.selectors.getBreakpointCount(state) === 3);
+  is(getBreakpointCount(getState()), 3, "Three breakpoints exist");
+});
+```
+
+2. Waiting for a Redux action to be dispatched
+
+```js
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html", "simple1");
+
+  await selectSource(dbg, "simple1");
+  is(countTabs(dbg), 1);
+  pressKey(dbg, "close");
+
+  // We use waitForDispatch() here to make sure that the CLOSE_TAB action has fired before our assertion counts the tabs
+  // Otherwise our assertion may count the tabs before the tab is actually closed
+  waitForDispatch(dbg, "CLOSE_TAB");
+  is(countTabs(dbg), 0);
+});
+```
+
+### Finding DOM elements
+You can find elements defined in the debugger instance's DOM by using either:
+
+1. `findElement()` which takes an element name from the shared `selectors` object defined in [helpers.js](https://github.com/firefox-devtools/debugger.html/blob/4a1622ae7d2230e79cae049ae0e95db7960c2cc7/test/mochitest/helpers.js).
+
+```js
+add_task(async function() {
+  const dbg = await initDebugger("doc-minified.html", "math.min.js");
+  await selectSource(dbg, "math.min.js", 2);
+
+  // We use findElement() here to find the pretty print button within the DOM.
+  // The second argument passed (prettyPrintButton) should correspond to an Object key to the selector variable in helpers.js
+  const prettyPrintButton = findElement(dbg, "prettyPrintButton");
+  ok(Boolean(prettyPrintButton), "Pretty Print Button is hidden");
+});
+```
+
+2. `findElementWithSelector()` which takes a selector.
+
+```js
+add_task(async function() {
+  const dbg = await initDebugger("doc-minified.html", "math.min.js");
+  await selectSource(dbg, "math.min.js", 2);
+
+  // We use findElement() here to find the pretty print button within the DOM.
+  // The second argument passed (prettyPrintButton) should correspond to an Object key to the selector variable in helpers.js
+  const prettyPrintButton = findElementWithSelector(dbg, ".source-footer .prettyPrint");
+  ok(Boolean(prettyPrintButton), "Pretty Print Button is hidden");
+});
+```
+
+### Evaluating in the debuggee ###
+If you want to evaluate a function in the debuggee context you can use the `invokeInTab` function. This invokes a function that is defined within the page itself.
+
+```js
+invokeInTab(dbg, "doSomething");
+```
+
+You can invoke functions that are from a page's external script file, like you would in the console. For example, if the tab's page "myPage.html" loads an external script "script.js" and within "script.js" there is a function "myScriptFunction()", you can invoke it like this:
+
+```js
+invokeInTab(dbg, "myScriptFunction")
+```
+
+You can also invoke document methods this way:
+
+```js
+invokeInTab(dbg, "content.document.querySelector('.source-footer .prettyPrint')")
+
+// You can also click a button this way
+invokeInTab(dbg, "content.document.querySelector('.source-footer .prettyPrint').click()")
+```
+
+### Using Debugger (DBG) helpers ###
+The `dbg` object returned by `initDebugger()` has several helpful properties, e.g., `actions`, `selectors`, `getState`, `store`, `toolbox`, `win`. [Click here](https://github.com/firefox-devtools/debugger.html/blob/7cdf5a1e99de51a551a5814f34ca8fb7506e06fb/docs/dbg.md) to learn more about these helpers.
+
+## Adding New Test Files ##
+
+If you add new tests files, make sure to list them in the `browser.ini` file. You will see the other test files there. Add a new entry with the same format as the others. You can also add new JS or HTML files by listing in under `support-files`.
+
+## Debugging Intermittents ##
+
+Intermittents are when a test succeeds most the time (~95%) of the time, but not all the time. There are several easy traps that result in intermittents:
+
+### Browser Inconsistencies ###
+Sometimes the server is not as consistent as you would like. For example, reloading can sometimes cause sources to load out of order, or stepping too quickly can cause the debugger to enter a bad state.
+
+A memorable example of this type of inconsistency came when debugging [stepping behavior](https://github.com/firefox-devtools/debugger.html/commit/7e54e6b46181b747a828ab2dc1db96c88313db95#diff-4fb7729ef51f162ae50b7c3bc020a1e3). It turns out that 1% of the time the browser toolbox will step into an unexpected location. The solution is to loosen our expectations :)
+
+### Missed Action ###
+Sometimes action "B" can fire before action "A" is done. This is a race condition that can be hard to track down. When you suspect this might happen, it is a good practice to start listening for "B" before you fire action "A".
+
+[Here's](https://github.com/firefox-devtools/debugger.html/commit/7b4762d9333108b15d81bc41e12182370c81e81c) an example where this happened with reloading.
+
+### State Changes ###
+One common way tests start failing occurs when the Redux actions introduces a new asynchronous operation. A good way to safe guard your tests is to wait on state to have certain values.
+
+For example, a test that we fixed was [pretty printing](https://github.com/firefox-devtools/debugger.html/commit/6a66ce54faf8239fb358462c53c022a75615aae6#diff-a81153d2e92178917a135261f4245c39R12). The test initially waited for the "select source" action to fire, which wasn't predictable. Switching the test to wait for the formatted source to exist first simplified the test tremendously.
+
+## Videos ##
 
 If you're looking for some tutorials on how to write and debug mochitests
 
@@ -64,113 +345,11 @@ If you're looking for some tutorials on how to write and debug mochitests
 [testing]: https://www.youtube.com/watch?v=5K9Sx5529JE&t=547s
 [testing2]: https://www.youtube.com/watch?v=E3QIwrcKnwg
 
-### Logging
+## Appendix ##
 
-The mochitests run in a special environment, which make `console.log` a little different than usual.
-`console.log` inside the test will print to the terminal. `console.log` in the debugger source, will be redirected to the browser console and will not be outputed. This is why we recommend using the special firefox `dump` call which is available everywhere.
+### Mochitest CLI
 
-If you want a convenience method for logging in the test, `log` is a bit cleaner than `dump`.
-
-```js
-console.log(">>> YO");
-log("FOO", { t: 3 });
-dump(">> FOOO\n");
-```
-
-### Pausing the test
-
-There are two ways to pause the tests and see what is going on.
-
-The first is to add a `debugger` statement to the test and run `yarn mochid {test_name}` (ex: `dbg-sources`). Here you'll have to click a modal when the test opens. When the test pauses, the browser toolbox will show your test with the `dbg` object you can interact with.
-
-The other way is to add `await waitForever()` to your test. This stops the test and gives you a chance to interact with the debugger as the user would. Both ways of pausing are useful for different use cases!
-
-### Waiting in a test
-
-It's really common to want to wait for something to happen in a test. Generally we wait for one of two things to happen:
-
-- waiting for the Redux state to change
-- waiting for an action to be dispatched
-
-```js
-await waitForState(dbg, state => isPaused(state));
-await waitForDispatch(dbg, "STEP_OVER";)
-```
-
-### Testing the DOM
-
-You can find common elements in the debugger with the `findElement` function,
-which use shared selectors. You can also find any element with the
-`findElementWithSelector` function.
-
-```js
-findElement(dbg, "sourceNode", 3);
-findElementWithSelector(dbg, ".sources-list .focused");
-```
-
-### Evaluating in the debuggee
-
-If you want to evaluate a function in the debuggee context you can use
-the `invokeInTab` function. Under the hood it is using `ContentTask.spawn`.
-
-```js
-invokeInTab(dbg, "doSomething");
-```
-
-```js
-ContentTask.spawn(gBrowser.selectedBrowser, null, function*() {
-  content.wrappedJSObject.foo();
-});
-```
-
-The above calls the function `foo` that exists in the page itself. You can also access the DOM this way: `content.document.querySelector`, if you want to click a button or do other things. You can even you use assertions inside this callback to check DOM state.
-
-### Debugging Tips
-
-The first step for debugging an integration test is establishing a clear sequence of events: where did the test break and what were the events that preceded it.
-
-The mochitest logs provide some context:
-
-1.  The actions that fired
-2.  Assertion Passes/Failures
-3.  Events that the test waited for: dispatches, state changes
-
-> NOTE: it might be nice to run the tests in headless mode: `yarn mochih browser_dbg-editor-highlight`
-
-![](https://shipusercontent.com/90d3d0484aedcdbe9e2bc1aa291a6eb8/Screen%20Shot%202017-10-26%20at%205.42.41%20PM.png)
-
-**In depth [walk through][ex]**
-
-[ex]: https://docs.google.com/document/d/1kH36V0bue0U_8Jmd2ohMutByMf4g8_iFNbTCx15d0kE/edit#
-
-The next step is to add additional logging in the test and debugger code with `info` calls.
-We recommend prefixing your logs and formatting them so they are easy to scan e.g.:
-
-- `info(">> Add breakpoint ${line} -> ${condition}\n")`
-- `info(">> Current breakpoints ${breakpoints.map(bp => bp.location.line).join(", ")}\n")`
-- `info(">> Symbols for source ${source.url} ${JSON.stringify(symbols)}\n")`
-
-At some point, it can be nice to pause the test and debug it. Mochitest makes it easy to pause the test at `debugger` statements with the `--jsdebugger` flag.
-You can run the test with `yarn mochid {test_name}` (ex: `browser_dbg-editor-highlight`).
-
-![](https://shipusercontent.com/e8441c77ab9ff6e84e5561b05bc25da2/Screen%20Shot%202017-10-26%20at%205.45.05%20PM.png)
-![](https://shipusercontent.com/57e41ae7227a46b2b6ae8b66956729ea/Screen%20Shot%202017-10-26%20at%205.44.54%20PM.png)
-
-#### Debugging Intermittents
-
-Intermittents are when a test succeeds most the time (95%) of the time, but not all the time.
-There are several easy traps that result in intermittents:
-
-- **browser inconsistencies** sometimes the server is not as consistent as you would like. For instance, reloading can sometimes cause sources to load out of order. Also stepping too quickly can cause the debugger to enter a bad state. A memorable example of this type of inconsistency came when debugging stepping behavior. It turns out that 1% of the time the browser toolbox will step into an [unexpected location][server-oops]. The solution is too loosen our expectations :)
-- **missed actions** sometimes action "B" can fire before action "A" is done. This is a race condition that can be hard to track down. When you suspect this might happen, it is a good practice to start listening for "B" before you fire action "A". Here's an example where this happened with [reloading][waiting].
-- **state changes** One common way tests start failing occurs when the redux actions introduces a new asynchronous operation. A good way to safe guard your tests is to wait on state to have certain values. An example, of a test that we recently fixed was [pretty printing][pretty-printing]. The test initially waited for the "select source" action to fire, which was occasionally racey. Switching the test to wait for the formatted source to exist simplified the test tremendously.
-
-### Appendix
-
-#### Mochitest CLI
-
-The mochitest cli has a lot of advanced options that are worth learning about.
-Here is a quick intro in how it can be used
+The mochitest cli has a lot of advanced options that are worth learning about. Here is a quick intro in how it can be used
 
 ```
 cd firefox
@@ -179,88 +358,9 @@ cd firefox
 ./mach mochitest --jsdebugger browser_dbg-editor-highlight # runs one test with the browser toolbox open
 ```
 
-Visit the [mochitest](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Mochitest) MDN page to learn more about mochitests and more advanced arguments. A few tips:
+Visit the [mochitest](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Mochitest) MDN page to learn more about Mochitests and its more advanced arguments.
 
-#### For Windows Developers
-
-The detailed instructions for setting up your environment to build Firefox for Windows can be found [here](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites). You need to install the latest `MozBuild` package. You can open a unix-flavor shell by starting:
-
-```
-C:\mozilla-build\start-shell.bat
-```
-
-In the shell, navigate to the debugger.html project folder, and follow the Getting Started instructions as mentioned.
-
-### Watching for Changes
-
-The mochitest are running against the compiled debugger bundle inside the Firefox checkout. This means that you need to update the bundle whenever you make code changes. `prepare-mochitests-dev` does this for you initially, but you can manually update it with:
-
-```
-yarn copy
-```
-
-That will build the debugger and copy over all the relevant files into `firefox`, including mochitests. If you want it to only symlink the mochitests directory, pass `--symlink-mochitests` (which is what `prepare-mochitests-dev` does).
-
-It's annoying to have to manually update the bundle every single time though. If you want to automatically update the bundle in Firefox whenever you make a change, run this:
-
-```
-yarn watch
-```
-
-Now you can make code changes the bundle will be automatically built for you inside `firefox`, and you can simply run mochitests and edit code as much as you like.
-
-If you see an `ENOENT` error when running either of these commands, like below:
-
-```
-{ Error: ENOENT: no such file or directory, open '/path/to/debugger.html/firefox/devtools/client/jar.mn'
-    at Object.fs.openSync (fs.js:646:18)
-    at Object.fs.readFileSync (fs.js:551:33)
-    at updateFile (/path/to/debugger.html/bin/copy-assets.js:29:17)
-    at copySVGs (/path/to/debugger.html/bin/copy-assets.js:102:3)
-    at start (/path/to/debugger.html/bin/copy-assets.js:225:3)
-    at module.exports (/path/to/debugger.html/bin/copy-assets.js:319:12)
-    at start (/path/to/debugger.html/bin/copy.js:23:13)
-    at Object.<anonymous> (/path/to/debugger.html/bin/copy.js:50:1)
-    at Module._compile (module.js:652:30)
-    at Object.Module._extensions..js (module.js:663:10)
-  errno: -2,
-  code: 'ENOENT',
-  syscall: 'open',
-  path: '/path/to/debugger.html/firefox/devtools/client/jar.mn' }
-```
-
-It may be that you have not cloned the latest `mozilla-central` repository, or it does not exist at the path you've provided. You can clone the latest `mozilla-central` by running the following command:
-
-```
-./bin/prepare-mochitests-dev
-```
-
-## Adding New Tests
-
-If you add new tests, make sure to list them in the `browser.ini` file. You will see the other tests there. Add a new entry with the same format as the others. You can also add new JS or HTML files by listing in under `support-files`.
-
-## API
-
-In addition to the standard Mochitest API, we provide the following functions to help write tests. All of these expect a `dbg` context which is returned from `initDebugger` which should be called at the beginning of the test. An example skeleton test looks like this:
-
-```js
-add_task(function*() {
-  const dbg = yield initDebugger("doc_simple.html", "code_simple.js");
-  // do some stuff
-  ok(state.foo, "Foo is OK");
-});
-```
-
-The Debugger Mochitest API Documentation can be found [here](https://firefox-devtools.github.io/debugger.html/reference#mochitest).
-
-[head]: https://github.com/firefox-devtools/debugger.html/blob/master/test/mochitest/head.js
-[mochitests]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Mochitest
-[waiting]: https://github.com/firefox-devtools/debugger.html/commit/7b4762d9333108b15d81bc41e12182370c81e81c
-[server-oops]: https://github.com/firefox-devtools/debugger.html/commit/7e54e6b46181b747a828ab2dc1db96c88313db95#diff-4fb7729ef51f162ae50b7c3bc020a1e3
-[pretty-printing]: https://github.com/firefox-devtools/debugger.html/commit/6a66ce54faf8239fb358462c53c022a75615aae6#diff-a81153d2e92178917a135261f4245c39R12
-[local-config]: https://github.com/firefox-devtools/debugger.html/blob/master/docs/local-development.md#logging
-
-## Troubleshooting Test Harness
+### Troubleshooting Test Harness
 
 If symbolic link is suddenly lost between debugger.html and Firefox source, in your terminal, try the following
 

--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -373,9 +373,7 @@ If a symbolic link occurs, error message(s) will be displayed.
 
 3. Execute `./bin/prepare-mochitests-dev`.
 
-Running this command again allows the preparation script to check the integrity of the firefox directory and all symbolic
-links. It will then automatically execute `yarn copy` on your behalf, which ensures the symbolic linking process
-is complete.
+Running this command again allows the preparation script to check the integrity of the firefox directory and all symbolic links. It will then automatically execute `yarn copy` on your behalf, which ensures the symbolic linking process is complete.
 
 4. On a new terminal tab, execute the command to run your test again. If this failed, proceed to step 5.
 
@@ -397,7 +395,6 @@ If you are having issues running mochitest due to missing the Rust compiler, try
 
 5. Execute `./bin/prepare-mochitests-dev`.
 
-You may see warnings along the way and the process may
-appear to be frozen. Please be patient, this is expected as it will take a while to recompile. Warning messages does not mean the compilation process has failed.
+You may see warnings along the way and the process may appear to be frozen. Please be patient, this is expected as it will take a while to recompile. Warning messages does not mean the compilation process has failed.
 
 6. Repeat steps 2 and 3.


### PR DESCRIPTION
Wrote this based off of my own experience with Mochitests and what I would have found useful as I first started working with it. If I missed anything that could be valuable or there's a better approach to certain parts, let me know :)

### Summary of Changes

Updated mochitests.doc. Changes include:
- Clarified `Initial Setup` steps for both Mac and Windows users
- Updated steps with the Firefox build process (`./firefox/mach build`)
- Added Mochitests `Folder Overview`
- Added step-by-step tutorial of a basic Mochitests test with examples
- Consolidated sections related to debugging tests under `Debugging your tests`, which now includes logs, pausing with timeouts and pausing with debugger statements. Added examples where necessary
- Added `Test Writing Tips` which elaborates on common test patterns, e.g., Waiting in a test, Finding DOM elements, Evaluating in the debuggee, using DBG helpers
- Added link to [DBG helpers](https://github.com/firefox-devtools/debugger.html/blob/7cdf5a1e99de51a551a5814f34ca8fb7506e06fb/docs/dbg.md)
- Reformatted `Debugging Intermittents`
- Moved inline GIF to a link instead
- Removed `yarn watch` documentation and inline JPGs
